### PR TITLE
Add vision extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,12 @@ For simulations, 🤗 LeRobot comes with gymnasium environments that can be inst
 - [aloha](https://github.com/huggingface/gym-aloha)
 - [xarm](https://github.com/huggingface/gym-xarm)
 - [pusht](https://github.com/huggingface/gym-pusht)
+- [vision](https://github.com/ultralytics/ultralytics) (YOLO support)
+
+For YOLO support, install the `vision` extra:
+```bash
+pip install -e .[vision]
+```
 
 For instance, to install 🤗 LeRobot with aloha and pusht, use:
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ stretch = [
 test = ["pytest>=8.1.0", "pytest-cov>=5.0.0", "mock-serial>=0.0.1 ; sys_platform != 'win32'"]
 umi = ["imagecodecs>=2024.1.1"]
 video_benchmark = ["scikit-image>=0.23.2", "pandas>=2.2.2"]
+vision = ["ultralytics>=8"]
 xarm = ["gym-xarm>=0.1.1 ; python_version < '4.0'"]
 
 [tool.poetry]


### PR DESCRIPTION
## Summary
- add `vision` optional dependency for YOLO support
- document how to install the extra

## Testing
- `pytest -k vision -q` *(fails: ModuleNotFoundError: No module named 'serial')*

------
https://chatgpt.com/codex/tasks/task_e_68456a7446b48331b4506916e08b7e40