### PR TITLE
Add setup option to stereo vision demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,13 @@ For YOLO support, install the `vision` extra:
 pip install -e .[vision]
 ```
 
+You can then test a stereo camera setup with YOLO detections using:
+```bash
+python lerobot/scripts/test_stereo_vision.py --setup
+```
+The `--setup` flag launches an interactive prompt to select your cameras and
+saves the configuration for future runs.
+
 For instance, to install 🤗 LeRobot with aloha and pusht, use:
 ```bash
 pip install -e ".[aloha, pusht]"


### PR DESCRIPTION
## Summary
- allow interactive configuration of stereo vision script via `--setup`
- store selected cameras in `~/.lerobot/stereo_vision.json`
- document how to use this script in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'serial')*

------
https://chatgpt.com/codex/tasks/task_e_68457811a64083318842597030208c95