### PR TITLE
Add camera preview step during stereo vision setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ You can then test a stereo camera setup with YOLO detections using:
 python lerobot/scripts/test_stereo_vision.py --setup
 ```
 The `--setup` flag launches an interactive prompt to select your cameras and
-saves the configuration for future runs.
+shows a short live preview of each detected camera. Once you choose, the
+configuration is saved for future runs.
 
 For instance, to install 🤗 LeRobot with aloha and pusht, use:
 ```bash


### PR DESCRIPTION
## Summary
- add `_preview_camera` helper to show a live preview of a camera
- preview cameras in `_interactive_setup`
- mention camera preview in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'serial')*

------
https://chatgpt.com/codex/tasks/task_e_6845816445ec8331a4a2c5d96d7c7bcf