### PR TITLE
Add interactive stereo vision config

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,23 @@ with profile(
             # insert code to profile, potentially whole body of eval_policy function
 ```
 
+### Stereo vision demo
+
+Use `lerobot/scripts/test_stereo_vision.py` to experiment with stereo cameras and YOLO detections.
+Run the script once with `--setup` to select your cameras and resolution:
+
+```bash
+python lerobot/scripts/test_stereo_vision.py --setup
+```
+
+Your choices are saved to `~/.lerobot/stereo_config.json`. Subsequent runs will reuse this configuration:
+
+```bash
+python lerobot/scripts/test_stereo_vision.py
+```
+
+Provide `--config` to use a different configuration file.
+
 ## Citation
 
 If you want, you can cite this work with:


### PR DESCRIPTION
## Summary
- add `--config` and `--setup` flags to `test_stereo_vision.py`
- load or create camera configuration interactively
- document how to use the new feature in the README

## Testing
- `ruff check lerobot/scripts/test_stereo_vision.py README.md`
- `pytest -k "" -vv` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6845780d81808331aa7c6e6b147dc08e