### PR TITLE
Add manual control UI for SO101 arm

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ wandb login
 |       ├── eval.py                 # load policy and evaluate it on an environment
 |       ├── train.py                # train a policy via imitation learning and/or reinforcement learning
 |       ├── control_robot.py        # teleoperate a real robot, record data, run a policy
+|       ├── manual_control_ui.py    # simple GUI to manually move the SO101 follower
 |       ├── push_dataset_to_hub.py  # convert your dataset into LeRobot dataset format and upload it to the Hugging Face hub
 |       └── visualize_dataset.py    # load a dataset and render its demonstrations
 ├── outputs               # contains results of scripts execution: logs, videos, model checkpoints
@@ -258,6 +259,17 @@ A `LeRobotDataset` is serialised using several widespread file formats for each 
 - metadata are stored in plain json/jsonl files
 
 Dataset can be uploaded/downloaded from the HuggingFace hub seamlessly. To work on a local dataset, you can specify its location with the `root` argument if it's not in the default `~/.cache/huggingface/lerobot` location.
+
+### Manually control the SO101 arm
+
+For quick testing you can open a small Tkinter interface to send joint commands:
+```bash
+python lerobot/scripts/manual_control_ui.py \
+    --port /dev/ttyUSB0 \
+    --id my_awesome_follower_arm
+```
+
+The window lists each servo with its calibrated range and lets you enter goal positions. Press **Move** to command the arm.
 
 ### Evaluate a pretrained policy
 

--- a/lerobot/scripts/manual_control_ui.py
+++ b/lerobot/scripts/manual_control_ui.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+
+"""Simple Tkinter GUI to manually control a SO101 follower arm.
+
+Example:
+    python lerobot/scripts/manual_control_ui.py --port /dev/ttyUSB0 --id my_arm
+"""
+
+from __future__ import annotations
+
+import argparse
+import tkinter as tk
+from functools import partial
+
+from lerobot.common.robots.so101_follower import SO101Follower, SO101FollowerConfig
+from lerobot.common.motors import MotorNormMode
+
+
+def _norm_from_raw(bus, motor: str, raw: int) -> float:
+    calib = bus.calibration[motor]
+    min_r = calib.range_min
+    max_r = calib.range_max
+    drive_mode = bus.apply_drive_mode and calib.drive_mode
+    if bus.motors[motor].norm_mode is MotorNormMode.RANGE_M100_100:
+        norm = ((raw - min_r) / (max_r - min_r)) * 200 - 100
+        return -norm if drive_mode else norm
+    if bus.motors[motor].norm_mode is MotorNormMode.RANGE_0_100:
+        norm = ((raw - min_r) / (max_r - min_r)) * 100
+        return 100 - norm if drive_mode else norm
+    if bus.motors[motor].norm_mode is MotorNormMode.DEGREES:
+        mid = (min_r + max_r) / 2
+        max_res = bus.model_resolution_table[bus._id_to_model(calib.id)] - 1
+        return (raw - mid) * 360 / max_res
+    raise NotImplementedError
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Manual control UI for SO101 follower arm")
+    parser.add_argument("--port", required=True, help="Serial port of the arm")
+    parser.add_argument("--id", default="so101_manual", help="Robot identifier")
+    args = parser.parse_args()
+
+    cfg = SO101FollowerConfig(port=args.port, id=args.id)
+    robot = SO101Follower(cfg)
+    robot.connect(calibrate=False)
+
+    calib = robot.bus.read_calibration()
+
+    root = tk.Tk()
+    root.title("SO101 Manual Control")
+
+    entries: dict[str, tk.Entry] = {}
+
+    row = 0
+    for motor in robot.bus.motors:
+        mcal = calib[motor]
+        nmin = _norm_from_raw(robot.bus, motor, mcal.range_min)
+        nmax = _norm_from_raw(robot.bus, motor, mcal.range_max)
+        label = tk.Label(root, text=f"{motor} ({nmin:.1f} to {nmax:.1f})")
+        label.grid(row=row, column=0, padx=5, pady=5)
+        entry = tk.Entry(root, width=10)
+        entry.grid(row=row, column=1, padx=5, pady=5)
+        entries[motor] = entry
+        row += 1
+
+    def move() -> None:
+        action = {}
+        for motor, entry in entries.items():
+            val = entry.get().strip()
+            if not val:
+                continue
+            try:
+                action[f"{motor}.pos"] = float(val)
+            except ValueError:
+                continue
+        if action:
+            robot.send_action(action)
+
+    move_btn = tk.Button(root, text="Move", command=move)
+    move_btn.grid(row=row, column=0, columnspan=2, pady=10)
+
+    def on_close() -> None:
+        robot.disconnect()
+        root.destroy()
+
+    root.protocol("WM_DELETE_WINDOW", on_close)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `manual_control_ui.py` script for quick control of SO101
- document the new tool and show how to run it in the README

## Testing
- `ruff format lerobot/scripts/manual_control_ui.py`
- `ruff check lerobot/scripts/manual_control_ui.py`
- `pytest -k so101_follower -q` *(fails: ModuleNotFoundError: No module named 'serial')*

------
https://chatgpt.com/codex/tasks/task_e_6847f16c9f188331b28c0386d0a8604e