### PR TITLE
Add Stretch3 teleoperation options

### DIFF
--- a/lerobot/common/robots/stretch3/configuration_stretch3.py
+++ b/lerobot/common/robots/stretch3/configuration_stretch3.py
@@ -40,14 +40,14 @@ class Stretch3RobotConfig(RobotConfig):
                 rotation=-90,
             ),
             "head": RealSenseCameraConfig(
-                name="Intel RealSense D435I",
+                serial_number_or_name="Intel RealSense D435I",
                 fps=30,
                 width=640,
                 height=480,
                 rotation=90,
             ),
             "wrist": RealSenseCameraConfig(
-                name="Intel RealSense D405",
+                serial_number_or_name="Intel RealSense D405",
                 fps=30,
                 width=640,
                 height=480,

--- a/lerobot/teleoperate.py
+++ b/lerobot/teleoperate.py
@@ -48,6 +48,7 @@ from lerobot.common.robots import (  # noqa: F401
     make_robot_from_config,
     so100_follower,
     so101_follower,
+    stretch3,  # noqa: F401
 )
 from lerobot.common.teleoperators import (
     Teleoperator,
@@ -58,7 +59,12 @@ from lerobot.common.utils.robot_utils import busy_wait
 from lerobot.common.utils.utils import init_logging, move_cursor_up
 from lerobot.common.utils.visualization_utils import _init_rerun
 
-from .common.teleoperators import koch_leader, so100_leader, so101_leader  # noqa: F401
+from .common.teleoperators import (
+    koch_leader,
+    so100_leader,
+    so101_leader,
+    stretch3_gamepad,  # noqa: F401
+)
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- import `stretch3` robot and `stretch3_gamepad` teleoperator in teleoperate module
- fix RealSense camera parameters for Stretch3 configuration

## Testing
- `ruff format lerobot/common/robots/stretch3/configuration_stretch3.py lerobot/teleoperate.py`
- `python -m lerobot.teleoperate --help | grep -A1 -- '--robot.type'`
- `python -m lerobot.teleoperate --help | grep -A1 -- '--teleop.type'`


------
https://chatgpt.com/codex/tasks/task_e_684bf24ec8508331b0b0c5ea282fc820