### PR TITLE
Add Stretch3 teleoperation script

### DIFF
--- a/lerobot/common/robots/stretch3/README.md
+++ b/lerobot/common/robots/stretch3/README.md
@@ -109,7 +109,7 @@ python lerobot/scripts/control_robot.py \
     --robot.type=stretch \
     --control.type=teleoperate
 ```
-This is essentially the same as running `stretch_gamepad_teleop.py`
+This is essentially the same as running `lerobot/scripts/stretch_gamepad_teleop.py`
 
 **Record a dataset**
 Once you're familiar with the gamepad controls and after a bit of practice, you can try to record your first dataset with Stretch.

--- a/lerobot/common/robots/stretch3/configuration_stretch3.py
+++ b/lerobot/common/robots/stretch3/configuration_stretch3.py
@@ -40,14 +40,14 @@ class Stretch3RobotConfig(RobotConfig):
                 rotation=-90,
             ),
             "head": RealSenseCameraConfig(
-                name="Intel RealSense D435I",
+                serial_number_or_name="Intel RealSense D435I",
                 fps=30,
                 width=640,
                 height=480,
                 rotation=90,
             ),
             "wrist": RealSenseCameraConfig(
-                name="Intel RealSense D405",
+                serial_number_or_name="Intel RealSense D405",
                 fps=30,
                 width=640,
                 height=480,

--- a/lerobot/scripts/stretch_gamepad_teleop.py
+++ b/lerobot/scripts/stretch_gamepad_teleop.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+"""Simple script to teleoperate Stretch3 using an Xbox controller."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+from lerobot.common.robots.stretch3 import Stretch3, Stretch3RobotConfig
+from lerobot.common.teleoperators.stretch3_gamepad import (
+    Stretch3GamePad,
+    Stretch3GamePadConfig,
+)
+from lerobot.teleoperate import teleop_loop
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Teleoperate Stretch3 with a gamepad")
+    parser.add_argument("--fps", type=int, default=60, help="Maximum teleoperation frequency")
+    parser.add_argument(
+        "--display-data",
+        action="store_true",
+        help="Display camera feeds using rerun",
+    )
+    parser.add_argument(
+        "--duration",
+        type=float,
+        default=None,
+        help="Time in seconds to teleoperate before exiting",
+    )
+    args = parser.parse_args()
+
+    robot = Stretch3(Stretch3RobotConfig())
+    teleop = Stretch3GamePad(Stretch3GamePadConfig())
+
+    robot.connect()
+    teleop.connect()
+
+    try:
+        teleop_loop(
+            teleop,
+            robot,
+            args.fps,
+            display_data=args.display_data,
+            duration=args.duration,
+        )
+    except KeyboardInterrupt:
+        pass
+    finally:
+        teleop.disconnect()
+        robot.disconnect()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/lerobot/teleoperate.py
+++ b/lerobot/teleoperate.py
@@ -48,6 +48,7 @@ from lerobot.common.robots import (  # noqa: F401
     make_robot_from_config,
     so100_follower,
     so101_follower,
+    stretch3,  # noqa: F401
 )
 from lerobot.common.teleoperators import (
     Teleoperator,
@@ -58,7 +59,12 @@ from lerobot.common.utils.robot_utils import busy_wait
 from lerobot.common.utils.utils import init_logging, move_cursor_up
 from lerobot.common.utils.visualization_utils import _init_rerun
 
-from .common.teleoperators import koch_leader, so100_leader, so101_leader  # noqa: F401
+from .common.teleoperators import (
+    koch_leader,
+    so100_leader,
+    so101_leader,
+    stretch3_gamepad,  # noqa: F401
+)
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- add `stretch_gamepad_teleop.py` for controlling Stretch3 with a gamepad
- reference the new script in Stretch3 README

## Testing
- `ruff format lerobot/scripts/stretch_gamepad_teleop.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684bf24ec8508331b0b0c5ea282fc820