### PR TITLE
Add TCP leader-follower scripts

### DIFF
--- a/lerobot/common/network_utils.py
+++ b/lerobot/common/network_utils.py
@@ -1,0 +1,33 @@
+import ipaddress
+import socket
+from typing import Optional
+
+
+def discover_host(port: int, network_range: str | None = None, timeout: float = 0.3) -> Optional[str]:
+    """Scan the network to find a host with an open ``port``.
+
+    Args:
+        port: Port number to test on each IP.
+        network_range: Optional network range in CIDR notation. If ``None`` the
+            function infers the local ``/24`` network from the current hostname.
+        timeout: Connection timeout in seconds.
+
+    Returns:
+        The IP address of the first host that accepts the connection or ``None``
+        if nothing was found.
+    """
+    if network_range is None:
+        try:
+            local_ip = socket.gethostbyname(socket.gethostname())
+            network_range = ".".join(local_ip.split(".")[:3]) + ".0/24"
+        except OSError:
+            return None
+
+    net = ipaddress.ip_network(network_range, strict=False)
+    for ip in net.hosts():
+        try:
+            with socket.create_connection((str(ip), port), timeout=timeout):
+                return str(ip)
+        except OSError:
+            continue
+    return None

--- a/lerobot/scripts/follower_server.py
+++ b/lerobot/scripts/follower_server.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+
+"""Run the robot follower as a TCP server."""
+
+from __future__ import annotations
+
+import json
+import logging
+import socket
+from dataclasses import dataclass
+
+import draccus
+
+from lerobot.common.robots import RobotConfig, make_robot_from_config
+from lerobot.common.utils.utils import init_logging
+
+
+@dataclass
+class FollowerServerConfig:
+    robot: RobotConfig
+    port: int = 5555
+
+
+@draccus.wrap()
+def main(cfg: FollowerServerConfig) -> None:
+    init_logging()
+    robot = make_robot_from_config(cfg.robot)
+    robot.connect()
+
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind(("", cfg.port))
+    server.listen(1)
+    logging.info("Waiting for leader connection on port %d", cfg.port)
+    conn, addr = server.accept()
+    logging.info("Leader connected from %s", addr)
+
+    buffer = b""
+    try:
+        while True:
+            data = conn.recv(4096)
+            if not data:
+                break
+            buffer += data
+            while b"\n" in buffer:
+                line, buffer = buffer.split(b"\n", 1)
+                if not line:
+                    continue
+                action = json.loads(line.decode())
+                robot.send_action(action)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        conn.close()
+        server.close()
+        robot.disconnect()
+
+
+if __name__ == "__main__":
+    main()

--- a/lerobot/scripts/leader_client.py
+++ b/lerobot/scripts/leader_client.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+
+"""Leader script that discovers the follower and sends teleop actions."""
+
+from __future__ import annotations
+
+import json
+import logging
+import socket
+import time
+from dataclasses import dataclass
+
+import draccus
+
+from lerobot.common.network_utils import discover_host
+from lerobot.common.teleoperators import TeleoperatorConfig, make_teleoperator_from_config
+from lerobot.common.utils.robot_utils import busy_wait
+from lerobot.common.utils.utils import init_logging
+
+
+@dataclass
+class LeaderClientConfig:
+    teleop: TeleoperatorConfig
+    port: int = 5555
+    network_range: str | None = None
+    fps: int = 60
+
+
+@draccus.wrap()
+def main(cfg: LeaderClientConfig) -> None:
+    init_logging()
+    ip = discover_host(cfg.port, cfg.network_range)
+    if ip is None:
+        raise RuntimeError("Could not find follower host")
+    logging.info("Connecting to follower at %s:%d", ip, cfg.port)
+
+    sock = socket.create_connection((ip, cfg.port))
+    teleop = make_teleoperator_from_config(cfg.teleop)
+    teleop.connect()
+
+    try:
+        while True:
+            loop_start = time.perf_counter()
+            action = teleop.get_action()
+            sock.sendall(json.dumps(action).encode() + b"\n")
+            busy_wait(1 / cfg.fps - (time.perf_counter() - loop_start))
+    except KeyboardInterrupt:
+        pass
+    finally:
+        teleop.disconnect()
+        sock.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add network utility to discover follower host
- add follower server that exposes a TCP interface for robot actions
- add leader client that searches for the server and streams teleop actions

## Testing
- `SKIP=gitleaks pre-commit run --files lerobot/common/network_utils.py lerobot/scripts/follower_server.py lerobot/scripts/leader_client.py`

------
https://chatgpt.com/codex/tasks/task_e_684d60c15098833180600964b15c6cb6