### PR TITLE
Add follower networking

### DIFF
--- a/lerobot/common/robots/so100_follower/__init__.py
+++ b/lerobot/common/robots/so100_follower/__init__.py
@@ -1,3 +1,8 @@
-from .config_so100_follower import SO100FollowerConfig, SO100FollowerEndEffectorConfig
+from .config_so100_follower import (
+    SO100FollowerClientConfig,
+    SO100FollowerConfig,
+    SO100FollowerEndEffectorConfig,
+)
 from .so100_follower import SO100Follower
+from .so100_follower_client import SO100FollowerClient
 from .so100_follower_end_effector import SO100FollowerEndEffector

--- a/lerobot/common/robots/so100_follower/config_so100_follower.py
+++ b/lerobot/common/robots/so100_follower/config_so100_follower.py
@@ -61,3 +61,14 @@ class SO100FollowerEndEffectorConfig(SO100FollowerConfig):
             "z": 0.02,
         }
     )
+
+
+@RobotConfig.register_subclass("so100_follower_client")
+@dataclass
+class SO100FollowerClientConfig(RobotConfig):
+    remote_ip: str | None = None
+    port_zmq_cmd: int = 5555
+    port_zmq_observations: int = 5556
+    cameras: dict[str, CameraConfig] = field(default_factory=dict)
+    polling_timeout_ms: int = 15
+    connect_timeout_s: int = 5

--- a/lerobot/common/robots/so100_follower/so100.mdx
+++ b/lerobot/common/robots/so100_follower/so100.mdx
@@ -480,6 +480,26 @@ leader.disconnect()
 </hfoption>
 </hfoptions>
 
+## Teleoperate over the network
+
+Run the follower server on the Raspberry Pi:
+
+```bash
+python -m lerobot.common.robots.so100_follower.so100_follower_server
+```
+
+Then on your laptop run teleoperation using the follower client:
+
+```bash
+python -m lerobot.teleoperate \
+  --robot.type=so100_follower_client \
+  --teleop.type=so100_leader
+```
+
+If `remote_ip` is not provided, the client broadcasts a UDP discovery packet to
+find the server. You can override the ports with `--robot.port_zmq_cmd` and
+`--robot.port_zmq_observations`.
+
 Congrats 🎉, your robot is all set to learn a task on its own. Start training it by following this tutorial: [Getting started with real-world robots](./getting_started_real_world_robot)
 
 > [!TIP]

--- a/lerobot/common/robots/so100_follower/so100_follower_client.py
+++ b/lerobot/common/robots/so100_follower/so100_follower_client.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Client interface to control a remote SO100 follower arm."""
+
+import base64
+import json
+import logging
+from functools import cached_property
+from typing import Any, Dict, Optional
+
+import cv2
+import numpy as np
+import zmq
+
+from lerobot.common.errors import DeviceAlreadyConnectedError, DeviceNotConnectedError
+
+from ..robot import Robot
+from ..utils import discover_server
+from .config_so100_follower import SO100FollowerClientConfig
+
+logger = logging.getLogger(__name__)
+
+
+class SO100FollowerClient(Robot):
+    config_class = SO100FollowerClientConfig
+    name = "so100_follower_client"
+
+    def __init__(self, config: SO100FollowerClientConfig):
+        super().__init__(config)
+        self.config = config
+        self.remote_ip = config.remote_ip
+        self.port_zmq_cmd = config.port_zmq_cmd
+        self.port_zmq_observations = config.port_zmq_observations
+        self.polling_timeout_ms = config.polling_timeout_ms
+        self.connect_timeout_s = config.connect_timeout_s
+
+        self.zmq_context = None
+        self.zmq_cmd_socket = None
+        self.zmq_observation_socket = None
+        self._is_connected = False
+        self.last_observation: Dict[str, Any] = {}
+
+    @cached_property
+    def _motors_ft(self) -> Dict[str, type]:
+        return {
+            "shoulder_pan.pos": float,
+            "shoulder_lift.pos": float,
+            "elbow_flex.pos": float,
+            "wrist_flex.pos": float,
+            "wrist_roll.pos": float,
+            "gripper.pos": float,
+        }
+
+    @cached_property
+    def _cameras_ft(self) -> Dict[str, tuple[int, int, int]]:
+        return {name: (cfg.height, cfg.width, 3) for name, cfg in self.config.cameras.items()}
+
+    @cached_property
+    def observation_features(self) -> Dict[str, type | tuple]:
+        return {**self._motors_ft, **self._cameras_ft}
+
+    @cached_property
+    def action_features(self) -> Dict[str, type]:
+        return self._motors_ft
+
+    @property
+    def is_connected(self) -> bool:
+        return self._is_connected
+
+    @property
+    def is_calibrated(self) -> bool:
+        return True
+
+    def connect(self) -> None:
+        if self._is_connected:
+            raise DeviceAlreadyConnectedError("SO100FollowerClient already connected")
+
+        if self.remote_ip is None:
+            result = discover_server(port=self.port_zmq_cmd)
+            if result is None:
+                raise DeviceNotConnectedError("Could not discover follower server")
+            self.remote_ip, self.port_zmq_cmd = result
+
+        self.zmq_context = zmq.Context()
+        self.zmq_cmd_socket = self.zmq_context.socket(zmq.PUSH)
+        self.zmq_cmd_socket.connect(f"tcp://{self.remote_ip}:{self.port_zmq_cmd}")
+        self.zmq_cmd_socket.setsockopt(zmq.CONFLATE, 1)
+
+        self.zmq_observation_socket = self.zmq_context.socket(zmq.PULL)
+        self.zmq_observation_socket.connect(f"tcp://{self.remote_ip}:{self.port_zmq_observations}")
+        self.zmq_observation_socket.setsockopt(zmq.CONFLATE, 1)
+
+        poller = zmq.Poller()
+        poller.register(self.zmq_observation_socket, zmq.POLLIN)
+        socks = dict(poller.poll(self.connect_timeout_s * 1000))
+        if self.zmq_observation_socket not in socks or socks[self.zmq_observation_socket] != zmq.POLLIN:
+            raise DeviceNotConnectedError("Timeout waiting for follower server to connect")
+
+        self._is_connected = True
+
+    def calibrate(self) -> None:
+        pass
+
+    def _poll_and_get_latest_message(self) -> Optional[str]:
+        poller = zmq.Poller()
+        poller.register(self.zmq_observation_socket, zmq.POLLIN)
+        try:
+            socks = dict(poller.poll(self.polling_timeout_ms))
+        except zmq.ZMQError as e:  # noqa: BLE001
+            logger.error("ZMQ polling error: %s", e)
+            return None
+
+        if self.zmq_observation_socket not in socks:
+            return None
+
+        last_msg = None
+        while True:
+            try:
+                msg = self.zmq_observation_socket.recv_string(zmq.NOBLOCK)
+                last_msg = msg
+            except zmq.Again:
+                break
+        return last_msg
+
+    def _decode_image(self, image_b64: str) -> Optional[np.ndarray]:
+        if not image_b64:
+            return None
+        try:
+            jpg_data = base64.b64decode(image_b64)
+            np_arr = np.frombuffer(jpg_data, dtype=np.uint8)
+            frame = cv2.imdecode(np_arr, cv2.IMREAD_COLOR)
+            return frame
+        except Exception as e:  # noqa: BLE001
+            logger.error("Error decoding image: %s", e)
+            return None
+
+    def get_observation(self) -> Dict[str, Any]:
+        if not self._is_connected:
+            raise DeviceNotConnectedError("SO100FollowerClient is not connected")
+
+        msg = self._poll_and_get_latest_message()
+        if msg is None:
+            return self.last_observation
+
+        try:
+            obs = json.loads(msg)
+        except json.JSONDecodeError as e:  # noqa: BLE001
+            logger.error("Error decoding JSON: %s", e)
+            return self.last_observation
+
+        for cam_name in self._cameras_ft:
+            frame = self._decode_image(obs.get(cam_name, ""))
+            if frame is not None:
+                obs[cam_name] = frame
+            else:
+                obs.pop(cam_name, None)
+        self.last_observation = obs
+        return obs
+
+    def send_action(self, action: Dict[str, Any]) -> Dict[str, Any]:
+        if not self._is_connected:
+            raise DeviceNotConnectedError("SO100FollowerClient is not connected")
+        self.zmq_cmd_socket.send_string(json.dumps(action))
+        return action
+
+    def configure(self) -> None:
+        pass
+
+    def disconnect(self) -> None:
+        if not self._is_connected:
+            raise DeviceNotConnectedError("SO100FollowerClient is not connected")
+        self.zmq_observation_socket.close()
+        self.zmq_cmd_socket.close()
+        self.zmq_context.term()
+        self._is_connected = False

--- a/lerobot/common/robots/so100_follower/so100_follower_server.py
+++ b/lerobot/common/robots/so100_follower/so100_follower_server.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Server for remotely controlling a SO100 follower arm."""
+
+import base64
+import contextlib
+import json
+import logging
+import socket
+import threading
+import time
+from dataclasses import dataclass
+
+import cv2
+import zmq
+
+from .config_so100_follower import SO100FollowerConfig
+from .so100_follower import SO100Follower
+
+
+@dataclass
+class SO100FollowerServerConfig:
+    port_zmq_cmd: int = 5555
+    port_zmq_observations: int = 5556
+    discovery_port: int = 5005
+    connection_time_s: int = 30
+    watchdog_timeout_ms: int = 500
+    max_loop_freq_hz: int = 30
+
+
+class SO100FollowerServer:
+    def __init__(self, config: SO100FollowerServerConfig):
+        self.port_zmq_cmd = config.port_zmq_cmd
+        self.zmq_context = zmq.Context()
+        self.zmq_cmd_socket = self.zmq_context.socket(zmq.PULL)
+        self.zmq_cmd_socket.setsockopt(zmq.CONFLATE, 1)
+        self.zmq_cmd_socket.bind(f"tcp://*:{config.port_zmq_cmd}")
+
+        self.zmq_observation_socket = self.zmq_context.socket(zmq.PUSH)
+        self.zmq_observation_socket.setsockopt(zmq.CONFLATE, 1)
+        self.zmq_observation_socket.bind(f"tcp://*:{config.port_zmq_observations}")
+
+        self.discovery_port = config.discovery_port
+        self._running = True
+        self._discovery_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self._discovery_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._discovery_socket.bind(("", self.discovery_port))
+        self._discovery_thread = threading.Thread(target=self._discovery_loop, daemon=True)
+        self._discovery_thread.start()
+
+        self.connection_time_s = config.connection_time_s
+        self.watchdog_timeout_ms = config.watchdog_timeout_ms
+        self.max_loop_freq_hz = config.max_loop_freq_hz
+
+    def _discovery_loop(self) -> None:
+        while self._running:
+            try:
+                data, addr = self._discovery_socket.recvfrom(1024)
+                if data == b"LEROBOT_DISCOVERY":
+                    self._discovery_socket.sendto(str(self.port_zmq_cmd).encode(), addr)
+            except OSError:
+                break
+
+    def disconnect(self) -> None:
+        self._running = False
+        with contextlib.suppress(OSError):
+            self._discovery_socket.close()
+        self.zmq_observation_socket.close()
+        self.zmq_cmd_socket.close()
+        self.zmq_context.term()
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    logging.info("Configuring SO100 follower")
+    robot_config = SO100FollowerConfig()
+    robot = SO100Follower(robot_config)
+
+    logging.info("Connecting SO100 follower")
+    robot.connect()
+
+    host_config = SO100FollowerServerConfig()
+    host = SO100FollowerServer(host_config)
+
+    last_cmd_time = time.time()
+    watchdog_active = False
+    logging.info("Waiting for commands...")
+    try:
+        start = time.perf_counter()
+        duration = 0
+        while duration < host.connection_time_s:
+            loop_start_time = time.time()
+            try:
+                msg = host.zmq_cmd_socket.recv_string(zmq.NOBLOCK)
+                data = dict(json.loads(msg))
+                robot.send_action(data)
+                last_cmd_time = time.time()
+                watchdog_active = False
+            except zmq.Again:
+                if not watchdog_active:
+                    logging.warning("No command available")
+            except Exception as e:  # noqa: BLE001
+                logging.error("Message fetching failed: %s", e)
+
+            now = time.time()
+            if (now - last_cmd_time > host.watchdog_timeout_ms / 1000) and not watchdog_active:
+                logging.warning(
+                    f"Command not received for more than {host.watchdog_timeout_ms} milliseconds."
+                )
+                watchdog_active = True
+
+            last_observation = robot.get_observation()
+
+            for cam_key in robot.cameras:
+                ret, buffer = cv2.imencode(
+                    ".jpg", last_observation[cam_key], [int(cv2.IMWRITE_JPEG_QUALITY), 90]
+                )
+                if ret:
+                    last_observation[cam_key] = base64.b64encode(buffer).decode("utf-8")
+                else:
+                    last_observation[cam_key] = ""
+
+            try:
+                host.zmq_observation_socket.send_string(json.dumps(last_observation), flags=zmq.NOBLOCK)
+            except zmq.Again:
+                logging.info("Dropping observation, no client connected")
+
+            elapsed = time.time() - loop_start_time
+            time.sleep(max(1 / host.max_loop_freq_hz - elapsed, 0))
+            duration = time.perf_counter() - start
+    except KeyboardInterrupt:
+        logging.info("Keyboard interrupt received. Exiting...")
+    finally:
+        logging.info("Shutting down SO100 follower server.")
+        robot.disconnect()
+        host.disconnect()
+
+    logging.info("Finished SO100 follower cleanly")
+
+
+if __name__ == "__main__":
+    main()

--- a/lerobot/common/robots/so101_follower/__init__.py
+++ b/lerobot/common/robots/so101_follower/__init__.py
@@ -1,2 +1,3 @@
-from .config_so101_follower import SO101FollowerConfig
+from .config_so101_follower import SO101FollowerClientConfig, SO101FollowerConfig
 from .so101_follower import SO101Follower
+from .so101_follower_client import SO101FollowerClient

--- a/lerobot/common/robots/so101_follower/config_so101_follower.py
+++ b/lerobot/common/robots/so101_follower/config_so101_follower.py
@@ -39,3 +39,14 @@ class SO101FollowerConfig(RobotConfig):
 
     # Set to `True` for backward compatibility with previous policies/dataset
     use_degrees: bool = False
+
+
+@RobotConfig.register_subclass("so101_follower_client")
+@dataclass
+class SO101FollowerClientConfig(RobotConfig):
+    remote_ip: str | None = None
+    port_zmq_cmd: int = 5555
+    port_zmq_observations: int = 5556
+    cameras: dict[str, CameraConfig] = field(default_factory=dict)
+    polling_timeout_ms: int = 15
+    connect_timeout_s: int = 5

--- a/lerobot/common/robots/so101_follower/so101.mdx
+++ b/lerobot/common/robots/so101_follower/so101.mdx
@@ -375,6 +375,25 @@ leader.disconnect()
 </hfoption>
 </hfoptions>
 
+## Teleoperate over the network
+
+Run the follower server on the Raspberry Pi:
+
+```bash
+python -m lerobot.common.robots.so101_follower.so101_follower_server
+```
+
+Then on your laptop run teleoperation using the follower client:
+
+```bash
+python -m lerobot.teleoperate \
+  --robot.type=so101_follower_client \
+  --teleop.type=so101_leader
+```
+
+Without a `remote_ip`, the client sends a UDP broadcast to discover the server.
+Ports can be set with `--robot.port_zmq_cmd` and `--robot.port_zmq_observations`.
+
 Congrats 🎉, your robot is all set to learn a task on its own. Start training it by following this tutorial: [Getting started with real-world robots](./getting_started_real_world_robot)
 
 > [!TIP]

--- a/lerobot/common/robots/so101_follower/so101_follower_client.py
+++ b/lerobot/common/robots/so101_follower/so101_follower_client.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Client interface to control a remote SO101 follower arm."""
+
+import base64
+import json
+import logging
+from functools import cached_property
+from typing import Any, Dict, Optional
+
+import cv2
+import numpy as np
+import zmq
+
+from lerobot.common.errors import DeviceAlreadyConnectedError, DeviceNotConnectedError
+
+from ..robot import Robot
+from ..utils import discover_server
+from .config_so101_follower import SO101FollowerClientConfig
+
+logger = logging.getLogger(__name__)
+
+
+class SO101FollowerClient(Robot):
+    config_class = SO101FollowerClientConfig
+    name = "so101_follower_client"
+
+    def __init__(self, config: SO101FollowerClientConfig):
+        super().__init__(config)
+        self.config = config
+        self.remote_ip = config.remote_ip
+        self.port_zmq_cmd = config.port_zmq_cmd
+        self.port_zmq_observations = config.port_zmq_observations
+        self.polling_timeout_ms = config.polling_timeout_ms
+        self.connect_timeout_s = config.connect_timeout_s
+
+        self.zmq_context = None
+        self.zmq_cmd_socket = None
+        self.zmq_observation_socket = None
+        self._is_connected = False
+        self.last_observation: Dict[str, Any] = {}
+
+    @cached_property
+    def _motors_ft(self) -> Dict[str, type]:
+        return {
+            "shoulder_pan.pos": float,
+            "shoulder_lift.pos": float,
+            "elbow_flex.pos": float,
+            "wrist_flex.pos": float,
+            "wrist_roll.pos": float,
+            "gripper.pos": float,
+        }
+
+    @cached_property
+    def _cameras_ft(self) -> Dict[str, tuple[int, int, int]]:
+        return {name: (cfg.height, cfg.width, 3) for name, cfg in self.config.cameras.items()}
+
+    @cached_property
+    def observation_features(self) -> Dict[str, type | tuple]:
+        return {**self._motors_ft, **self._cameras_ft}
+
+    @cached_property
+    def action_features(self) -> Dict[str, type]:
+        return self._motors_ft
+
+    @property
+    def is_connected(self) -> bool:
+        return self._is_connected
+
+    @property
+    def is_calibrated(self) -> bool:
+        return True
+
+    def connect(self) -> None:
+        if self._is_connected:
+            raise DeviceAlreadyConnectedError("SO101FollowerClient already connected")
+
+        if self.remote_ip is None:
+            result = discover_server(port=self.port_zmq_cmd)
+            if result is None:
+                raise DeviceNotConnectedError("Could not discover follower server")
+            self.remote_ip, self.port_zmq_cmd = result
+
+        self.zmq_context = zmq.Context()
+        self.zmq_cmd_socket = self.zmq_context.socket(zmq.PUSH)
+        self.zmq_cmd_socket.connect(f"tcp://{self.remote_ip}:{self.port_zmq_cmd}")
+        self.zmq_cmd_socket.setsockopt(zmq.CONFLATE, 1)
+
+        self.zmq_observation_socket = self.zmq_context.socket(zmq.PULL)
+        self.zmq_observation_socket.connect(f"tcp://{self.remote_ip}:{self.port_zmq_observations}")
+        self.zmq_observation_socket.setsockopt(zmq.CONFLATE, 1)
+
+        poller = zmq.Poller()
+        poller.register(self.zmq_observation_socket, zmq.POLLIN)
+        socks = dict(poller.poll(self.connect_timeout_s * 1000))
+        if self.zmq_observation_socket not in socks or socks[self.zmq_observation_socket] != zmq.POLLIN:
+            raise DeviceNotConnectedError("Timeout waiting for follower server to connect")
+
+        self._is_connected = True
+
+    def calibrate(self) -> None:
+        pass
+
+    def _poll_and_get_latest_message(self) -> Optional[str]:
+        poller = zmq.Poller()
+        poller.register(self.zmq_observation_socket, zmq.POLLIN)
+        try:
+            socks = dict(poller.poll(self.polling_timeout_ms))
+        except zmq.ZMQError as e:  # noqa: BLE001
+            logger.error("ZMQ polling error: %s", e)
+            return None
+
+        if self.zmq_observation_socket not in socks:
+            return None
+
+        last_msg = None
+        while True:
+            try:
+                msg = self.zmq_observation_socket.recv_string(zmq.NOBLOCK)
+                last_msg = msg
+            except zmq.Again:
+                break
+        return last_msg
+
+    def _decode_image(self, image_b64: str) -> Optional[np.ndarray]:
+        if not image_b64:
+            return None
+        try:
+            jpg_data = base64.b64decode(image_b64)
+            np_arr = np.frombuffer(jpg_data, dtype=np.uint8)
+            frame = cv2.imdecode(np_arr, cv2.IMREAD_COLOR)
+            return frame
+        except Exception as e:  # noqa: BLE001
+            logger.error("Error decoding image: %s", e)
+            return None
+
+    def get_observation(self) -> Dict[str, Any]:
+        if not self._is_connected:
+            raise DeviceNotConnectedError("SO101FollowerClient is not connected")
+
+        msg = self._poll_and_get_latest_message()
+        if msg is None:
+            return self.last_observation
+
+        try:
+            obs = json.loads(msg)
+        except json.JSONDecodeError as e:  # noqa: BLE001
+            logger.error("Error decoding JSON: %s", e)
+            return self.last_observation
+
+        for cam_name in self._cameras_ft:
+            frame = self._decode_image(obs.get(cam_name, ""))
+            if frame is not None:
+                obs[cam_name] = frame
+            else:
+                obs.pop(cam_name, None)
+        self.last_observation = obs
+        return obs
+
+    def send_action(self, action: Dict[str, Any]) -> Dict[str, Any]:
+        if not self._is_connected:
+            raise DeviceNotConnectedError("SO101FollowerClient is not connected")
+        self.zmq_cmd_socket.send_string(json.dumps(action))
+        return action
+
+    def configure(self) -> None:
+        pass
+
+    def disconnect(self) -> None:
+        if not self._is_connected:
+            raise DeviceNotConnectedError("SO101FollowerClient is not connected")
+        self.zmq_observation_socket.close()
+        self.zmq_cmd_socket.close()
+        self.zmq_context.term()
+        self._is_connected = False

--- a/lerobot/common/robots/so101_follower/so101_follower_server.py
+++ b/lerobot/common/robots/so101_follower/so101_follower_server.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Server for remotely controlling a SO101 follower arm."""
+
+import base64
+import contextlib
+import json
+import logging
+import socket
+import threading
+import time
+from dataclasses import dataclass
+
+import cv2
+import zmq
+
+from .config_so101_follower import SO101FollowerConfig
+from .so101_follower import SO101Follower
+
+
+@dataclass
+class SO101FollowerServerConfig:
+    port_zmq_cmd: int = 5555
+    port_zmq_observations: int = 5556
+    discovery_port: int = 5005
+    connection_time_s: int = 30
+    watchdog_timeout_ms: int = 500
+    max_loop_freq_hz: int = 30
+
+
+class SO101FollowerServer:
+    def __init__(self, config: SO101FollowerServerConfig):
+        self.port_zmq_cmd = config.port_zmq_cmd
+        self.zmq_context = zmq.Context()
+        self.zmq_cmd_socket = self.zmq_context.socket(zmq.PULL)
+        self.zmq_cmd_socket.setsockopt(zmq.CONFLATE, 1)
+        self.zmq_cmd_socket.bind(f"tcp://*:{config.port_zmq_cmd}")
+
+        self.zmq_observation_socket = self.zmq_context.socket(zmq.PUSH)
+        self.zmq_observation_socket.setsockopt(zmq.CONFLATE, 1)
+        self.zmq_observation_socket.bind(f"tcp://*:{config.port_zmq_observations}")
+
+        self.discovery_port = config.discovery_port
+        self._running = True
+        self._discovery_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self._discovery_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._discovery_socket.bind(("", self.discovery_port))
+        self._discovery_thread = threading.Thread(target=self._discovery_loop, daemon=True)
+        self._discovery_thread.start()
+
+        self.connection_time_s = config.connection_time_s
+        self.watchdog_timeout_ms = config.watchdog_timeout_ms
+        self.max_loop_freq_hz = config.max_loop_freq_hz
+
+    def _discovery_loop(self) -> None:
+        while self._running:
+            try:
+                data, addr = self._discovery_socket.recvfrom(1024)
+                if data == b"LEROBOT_DISCOVERY":
+                    self._discovery_socket.sendto(str(self.port_zmq_cmd).encode(), addr)
+            except OSError:
+                break
+
+    def disconnect(self) -> None:
+        self._running = False
+        with contextlib.suppress(OSError):
+            self._discovery_socket.close()
+        self.zmq_observation_socket.close()
+        self.zmq_cmd_socket.close()
+        self.zmq_context.term()
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    logging.info("Configuring SO101 follower")
+    robot_config = SO101FollowerConfig()
+    robot = SO101Follower(robot_config)
+
+    logging.info("Connecting SO101 follower")
+    robot.connect()
+
+    host_config = SO101FollowerServerConfig()
+    host = SO101FollowerServer(host_config)
+
+    last_cmd_time = time.time()
+    watchdog_active = False
+    logging.info("Waiting for commands...")
+    try:
+        start = time.perf_counter()
+        duration = 0
+        while duration < host.connection_time_s:
+            loop_start_time = time.time()
+            try:
+                msg = host.zmq_cmd_socket.recv_string(zmq.NOBLOCK)
+                data = dict(json.loads(msg))
+                robot.send_action(data)
+                last_cmd_time = time.time()
+                watchdog_active = False
+            except zmq.Again:
+                if not watchdog_active:
+                    logging.warning("No command available")
+            except Exception as e:  # noqa: BLE001
+                logging.error("Message fetching failed: %s", e)
+
+            now = time.time()
+            if (now - last_cmd_time > host.watchdog_timeout_ms / 1000) and not watchdog_active:
+                logging.warning(
+                    f"Command not received for more than {host.watchdog_timeout_ms} milliseconds."
+                )
+                watchdog_active = True
+
+            last_observation = robot.get_observation()
+
+            for cam_key in robot.cameras:
+                ret, buffer = cv2.imencode(
+                    ".jpg", last_observation[cam_key], [int(cv2.IMWRITE_JPEG_QUALITY), 90]
+                )
+                if ret:
+                    last_observation[cam_key] = base64.b64encode(buffer).decode("utf-8")
+                else:
+                    last_observation[cam_key] = ""
+
+            try:
+                host.zmq_observation_socket.send_string(json.dumps(last_observation), flags=zmq.NOBLOCK)
+            except zmq.Again:
+                logging.info("Dropping observation, no client connected")
+
+            elapsed = time.time() - loop_start_time
+            time.sleep(max(1 / host.max_loop_freq_hz - elapsed, 0))
+            duration = time.perf_counter() - start
+    except KeyboardInterrupt:
+        logging.info("Keyboard interrupt received. Exiting...")
+    finally:
+        logging.info("Shutting down SO101 follower server.")
+        robot.disconnect()
+        host.disconnect()
+
+    logging.info("Finished SO101 follower cleanly")
+
+
+if __name__ == "__main__":
+    main()

--- a/lerobot/teleoperate.py
+++ b/lerobot/teleoperate.py
@@ -47,7 +47,9 @@ from lerobot.common.robots import (  # noqa: F401
     koch_follower,
     make_robot_from_config,
     so100_follower,
+    so100_follower_client,
     so101_follower,
+    so101_follower_client,
 )
 from lerobot.common.teleoperators import (
     Teleoperator,


### PR DESCRIPTION
## Summary
- enable teleop over network for SO100 and SO101 follower arms
- add UDP discovery utility for network clients
- create follower client/server classes
- document how to run follower server and connect remotely

## Testing
- `pre-commit run --files lerobot/common/robots/so100_follower/so100_follower_server.py lerobot/common/robots/so101_follower/so101_follower_server.py lerobot/common/robots/so100_follower/so100_follower_client.py lerobot/common/robots/so101_follower/so101_follower_client.py lerobot/common/robots/so100_follower/config_so100_follower.py lerobot/common/robots/so101_follower/config_so101_follower.py lerobot/common/robots/utils.py lerobot/teleoperate.py docs/source/so100.mdx docs/source/so101.mdx`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'serial')*

------
https://chatgpt.com/codex/tasks/task_e_6857d4c8a3508331b11fcd0ce0ef05fb