### PR TITLE
Fix follower server configuration

### DIFF
--- a/lerobot/common/robots/so100_follower/so100.mdx
+++ b/lerobot/common/robots/so100_follower/so100.mdx
@@ -482,10 +482,12 @@ leader.disconnect()
 
 ## Teleoperate over the network
 
-Run the follower server on the Raspberry Pi:
+Run the follower server on the Raspberry Pi (replace `/dev/ttyACM0` with the serial
+port of your arm):
 
 ```bash
-python -m lerobot.common.robots.so100_follower.so100_follower_server
+python -m lerobot.common.robots.so100_follower.so100_follower_server \
+  --robot.port=/dev/ttyACM0
 ```
 
 Then on your laptop run teleoperation using the follower client:

--- a/lerobot/common/robots/so100_follower/so100_follower_server.py
+++ b/lerobot/common/robots/so100_follower/so100_follower_server.py
@@ -25,6 +25,8 @@ import threading
 import time
 from dataclasses import dataclass
 
+import draccus
+
 import cv2
 import zmq
 
@@ -40,6 +42,12 @@ class SO100FollowerServerConfig:
     connection_time_s: int = 30
     watchdog_timeout_ms: int = 500
     max_loop_freq_hz: int = 30
+
+
+@dataclass
+class SO100FollowerServerCLIConfig:
+    robot: SO100FollowerConfig
+    server: SO100FollowerServerConfig = SO100FollowerServerConfig()
 
 
 class SO100FollowerServer:
@@ -84,17 +92,16 @@ class SO100FollowerServer:
         self.zmq_context.term()
 
 
-def main() -> None:
+@draccus.wrap()
+def main(cfg: SO100FollowerServerCLIConfig) -> None:
     logging.basicConfig(level=logging.INFO)
     logging.info("Configuring SO100 follower")
-    robot_config = SO100FollowerConfig()
-    robot = SO100Follower(robot_config)
+    robot = SO100Follower(cfg.robot)
 
     logging.info("Connecting SO100 follower")
     robot.connect()
 
-    host_config = SO100FollowerServerConfig()
-    host = SO100FollowerServer(host_config)
+    host = SO100FollowerServer(cfg.server)
 
     last_cmd_time = time.time()
     watchdog_active = False

--- a/lerobot/common/robots/so101_follower/so101.mdx
+++ b/lerobot/common/robots/so101_follower/so101.mdx
@@ -377,10 +377,12 @@ leader.disconnect()
 
 ## Teleoperate over the network
 
-Run the follower server on the Raspberry Pi:
+Run the follower server on the Raspberry Pi (replace `/dev/ttyACM0` with the serial
+port of your arm):
 
 ```bash
-python -m lerobot.common.robots.so101_follower.so101_follower_server
+python -m lerobot.common.robots.so101_follower.so101_follower_server \
+  --robot.port=/dev/ttyACM0
 ```
 
 Then on your laptop run teleoperation using the follower client:

--- a/lerobot/common/robots/so101_follower/so101_follower_server.py
+++ b/lerobot/common/robots/so101_follower/so101_follower_server.py
@@ -25,6 +25,8 @@ import threading
 import time
 from dataclasses import dataclass
 
+import draccus
+
 import cv2
 import zmq
 
@@ -40,6 +42,12 @@ class SO101FollowerServerConfig:
     connection_time_s: int = 30
     watchdog_timeout_ms: int = 500
     max_loop_freq_hz: int = 30
+
+
+@dataclass
+class SO101FollowerServerCLIConfig:
+    robot: SO101FollowerConfig
+    server: SO101FollowerServerConfig = SO101FollowerServerConfig()
 
 
 class SO101FollowerServer:
@@ -84,17 +92,16 @@ class SO101FollowerServer:
         self.zmq_context.term()
 
 
-def main() -> None:
+@draccus.wrap()
+def main(cfg: SO101FollowerServerCLIConfig) -> None:
     logging.basicConfig(level=logging.INFO)
     logging.info("Configuring SO101 follower")
-    robot_config = SO101FollowerConfig()
-    robot = SO101Follower(robot_config)
+    robot = SO101Follower(cfg.robot)
 
     logging.info("Connecting SO101 follower")
     robot.connect()
 
-    host_config = SO101FollowerServerConfig()
-    host = SO101FollowerServer(host_config)
+    host = SO101FollowerServer(cfg.server)
 
     last_cmd_time = time.time()
     watchdog_active = False


### PR DESCRIPTION
## Summary
- add CLI dataclasses and `draccus.wrap` to follower server scripts
- document how to specify the serial port when starting a server

## Testing
- `pre-commit run --files lerobot/common/robots/so101_follower/so101_follower_server.py lerobot/common/robots/so100_follower/so100_follower_server.py lerobot/common/robots/so101_follower/so101.mdx lerobot/common/robots/so100_follower/so100.mdx` *(fails: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.10')*

------
https://chatgpt.com/codex/tasks/task_e_68580deb42408331936e6ac83d3d8805