### PR TITLE
Improve calibration feedback

### DIFF
--- a/lerobot/common/robots/koch_follower/koch_follower.py
+++ b/lerobot/common/robots/koch_follower/koch_follower.py
@@ -94,6 +94,8 @@ class KochFollower(Robot):
 
         self.bus.connect()
         if not self.is_calibrated and calibrate:
+            reason = self.bus.calibration_mismatch_info()
+            logger.info(f"{self} not calibrated: {reason}. Starting calibration.")
             self.calibrate()
 
         for cam in self.cameras.values():

--- a/lerobot/common/robots/lekiwi/lekiwi.py
+++ b/lerobot/common/robots/lekiwi/lekiwi.py
@@ -114,6 +114,8 @@ class LeKiwi(Robot):
 
         self.bus.connect()
         if not self.is_calibrated and calibrate:
+            reason = self.bus.calibration_mismatch_info()
+            logger.info(f"{self} not calibrated: {reason}. Starting calibration.")
             self.calibrate()
 
         for cam in self.cameras.values():

--- a/lerobot/common/robots/so100_follower/so100_follower.py
+++ b/lerobot/common/robots/so100_follower/so100_follower.py
@@ -92,6 +92,8 @@ class SO100Follower(Robot):
 
         self.bus.connect()
         if not self.is_calibrated and calibrate:
+            reason = self.bus.calibration_mismatch_info()
+            logger.info(f"{self} not calibrated: {reason}. Starting calibration.")
             self.calibrate()
 
         for cam in self.cameras.values():

--- a/lerobot/common/robots/so101_follower/so101_follower.py
+++ b/lerobot/common/robots/so101_follower/so101_follower.py
@@ -92,6 +92,8 @@ class SO101Follower(Robot):
 
         self.bus.connect()
         if not self.is_calibrated and calibrate:
+            reason = self.bus.calibration_mismatch_info()
+            logger.info(f"{self} not calibrated: {reason}. Starting calibration.")
             self.calibrate()
 
         for cam in self.cameras.values():

--- a/lerobot/common/robots/viperx/viperx.py
+++ b/lerobot/common/robots/viperx/viperx.py
@@ -96,6 +96,8 @@ class ViperX(Robot):
 
         self.bus.connect()
         if not self.is_calibrated and calibrate:
+            reason = self.bus.calibration_mismatch_info()
+            logger.info(f"{self} not calibrated: {reason}. Starting calibration.")
             self.calibrate()
 
         for cam in self.cameras.values():

--- a/lerobot/common/teleoperators/koch_leader/koch_leader.py
+++ b/lerobot/common/teleoperators/koch_leader/koch_leader.py
@@ -75,6 +75,8 @@ class KochLeader(Teleoperator):
 
         self.bus.connect()
         if not self.is_calibrated and calibrate:
+            reason = self.bus.calibration_mismatch_info()
+            logger.info(f"{self} not calibrated: {reason}. Starting calibration.")
             self.calibrate()
 
         self.configure()

--- a/lerobot/common/teleoperators/so100_leader/so100_leader.py
+++ b/lerobot/common/teleoperators/so100_leader/so100_leader.py
@@ -72,6 +72,8 @@ class SO100Leader(Teleoperator):
 
         self.bus.connect()
         if not self.is_calibrated and calibrate:
+            reason = self.bus.calibration_mismatch_info()
+            logger.info(f"{self} not calibrated: {reason}. Starting calibration.")
             self.calibrate()
 
         self.configure()

--- a/lerobot/common/teleoperators/so101_leader/so101_leader.py
+++ b/lerobot/common/teleoperators/so101_leader/so101_leader.py
@@ -73,6 +73,8 @@ class SO101Leader(Teleoperator):
 
         self.bus.connect()
         if not self.is_calibrated and calibrate:
+            reason = self.bus.calibration_mismatch_info()
+            logger.info(f"{self} not calibrated: {reason}. Starting calibration.")
             self.calibrate()
 
         self.configure()

--- a/lerobot/common/teleoperators/widowx/widowx.py
+++ b/lerobot/common/teleoperators/widowx/widowx.py
@@ -76,6 +76,8 @@ class WidowX(Teleoperator):
 
         self.bus.connect()
         if not self.is_calibrated and calibrate:
+            reason = self.bus.calibration_mismatch_info()
+            logger.info(f"{self} not calibrated: {reason}. Starting calibration.")
             self.calibrate()
 
         self.configure()


### PR DESCRIPTION
## Summary
- add `calibration_mismatch_info` helper to `MotorsBus`
- log the calibration mismatch reason when connecting robots and teleoperators

## Testing
- `pre-commit run --files lerobot/common/motors/motors_bus.py lerobot/common/robots/so101_follower/so101_follower.py lerobot/common/robots/so100_follower/so100_follower.py lerobot/common/robots/koch_follower/koch_follower.py lerobot/common/robots/viperx/viperx.py lerobot/common/teleoperators/so101_leader/so101_leader.py lerobot/common/teleoperators/so100_leader/so100_leader.py lerobot/common/teleoperators/koch_leader/koch_leader.py lerobot/common/teleoperators/widowx/widowx.py lerobot/common/robots/lekiwi/lekiwi.py`
- `pytest tests/motors/test_feetech.py::test_is_calibrated -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_685d6e62fb288331aa98bea7d4a8c2f1